### PR TITLE
Improved CPU info surveying

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ if(NOCTURNE_ARCH STREQUAL "x86")
 		kernel/src/arch/x86/asm/paging.s
 		kernel/src/arch/x86/asm/regs.s 
 		kernel/src/lib/setjmp.s 
-		kernel/src/arch/x86/asm/switch_task.s 
+		kernel/src/arch/x86/asm/switch_task.s
 	)
 
 	set(C_SRC
@@ -131,6 +131,8 @@ if(NOCTURNE_ARCH STREQUAL "x86")
 		kernel/src/drv/cmos.c
         kernel/src/sys/isr.c 
 		kernel/src/drv/video/intel.c
+		kernel/src/arch/x86/cpuinfo.c
+		kernel/src/arch/x86/cpuvendor.c
 	)
 elseif(NOCTURNE_ARCH STREQUAL "armv7")
 	set(C_SRC kernel/src/arch/armv7/init.c)
@@ -188,8 +190,7 @@ set(C_SRC
 	kernel/src/lib/math/cos.c 
 	kernel/src/lib/math/tan.c 
 	kernel/src/lib/math/sqrt.c 
-	kernel/src/lib/math/cbrt.c 
-	kernel/src/sys/cpuid.c	
+	kernel/src/lib/math/cbrt.c 	
 	kernel/src/drv/disk/ata.c 
 	kernel/src/drv/disk/atapi.c 
 	kernel/src/drv/disk/memdisk.c 

--- a/kernel/include/arch/bitops.h
+++ b/kernel/include/arch/bitops.h
@@ -1,0 +1,3 @@
+#pragma once
+
+extern __attribute__((const)) int bit_ls(unsigned long x);

--- a/kernel/include/arch/x86/asm.h
+++ b/kernel/include/arch/x86/asm.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#define CONCAT(a, b) a##b
+
+#define __asm_reg_con_1 "q"
+#define __asm_reg_con_2 "r"
+#define __asm_reg_con_4 "r"
+#define __asm_reg_con_8 "r"
+#define __asm_reg_con(size) __asm_reg_con_##size
+
+#define __asm_imm_con_1 "i"
+#define __asm_imm_con_2 "i"
+#define __asm_imm_con_4 "i"
+#define __asm_imm_con_8 "e"
+#define __asm_imm_con(size) __asm_imm_con_##size
+
+#define __asm_op_suffix_1(operand) operand "b "
+#define __asm_op_suffix_2(operand) operand "w "
+#define __asm_op_suffix_4(operand) operand "l "
+#define __asm_op_suffix_8(operand) operand "q "
+#define __asm_op(operand, size) CONCAT(__asm_op_suffix_, size)(operand)

--- a/kernel/include/arch/x86/cpu_vendors.h
+++ b/kernel/include/arch/x86/cpu_vendors.h
@@ -1,0 +1,96 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* Created by: NotYourFox, 2025 */
+
+#pragma once
+
+#include <common.h>
+
+#define CPUID_VENDOR_AMD "AuthenticAMD"
+#define CPUID_VENDOR_AMD_OLD "AMDisbetter!" // Early engineering samples of AMD K5 processor
+#define CPUID_VENDOR_INTEL "GenuineIntel"
+#define CPUID_VENDOR_VIA "VIA VIA VIA "
+#define CPUID_VENDOR_TRANSMETA "GenuineTMx86"
+#define CPUID_VENDOR_TRANSMETA_OLD "TransmetaCPU"
+#define CPUID_VENDOR_CYRIX "CyrixInstead"
+#define CPUID_VENDOR_CENTAUR "CentaurHauls"
+#define CPUID_VENDOR_NEXGEN "NexGenDriven"
+#define CPUID_VENDOR_UMC "UMC UMC UMC "
+#define CPUID_VENDOR_SIS "SiS SiS SiS "
+#define CPUID_VENDOR_NSC "Geode by NSC"
+#define CPUID_VENDOR_RISE "RiseRiseRise"
+#define CPUID_VENDOR_VORTEX "Vortex86 SoC"
+#define CPUID_VENDOR_AO486 "MiSTer AO486"
+#define CPUID_VENDOR_AO486_OLD "GenuineAO486"
+#define CPUID_VENDOR_ZHAOXIN "  Shanghai  "
+#define CPUID_VENDOR_HYGON "HygonGenuine"
+#define CPUID_VENDOR_ELBRUS "E2K MACHINE "
+
+// Vendor strings from hypervisors.
+#define CPUID_VENDOR_QEMU "TCGTCGTCGTCG"
+#define CPUID_VENDOR_KVM "KVMKVMKVM\0\0\0"
+#define CPUID_VENDOR_KVM_ALT "Linux KVM Hv"
+#define CPUID_VENDOR_VMWARE "VMwareVMware"
+#define CPUID_VENDOR_VIRTUALBOX "VBoxVBoxVBox"
+#define CPUID_VENDOR_XEN "XenVMMXenVMM"
+#define CPUID_VENDOR_HYPERV "Microsoft Hv"
+#define CPUID_VENDOR_PARALLELS " prl hyperv "
+#define CPUID_VENDOR_PARALLELS_ALT " lrpepyh vr "
+#define CPUID_VENDOR_BHYVE "bhyve bhyve "
+#define CPUID_VENDOR_QNX " QNXQVMBSQG "
+
+enum {
+    X86_VENDOR_AMD,
+    X86_VENDOR_AMD_OLD,
+    X86_VENDOR_INTEL,
+    X86_VENDOR_VIA,
+    X86_VENDOR_TRANSMETA,
+    X86_VENDOR_TRANSMETA_OLD,
+    X86_VENDOR_CYRIX,
+    X86_VENDOR_CENTAUR,
+    X86_VENDOR_NEXGEN,
+    X86_VENDOR_UMC,
+    X86_VENDOR_SIS,
+    X86_VENDOR_NSC,
+    X86_VENDOR_RISE,
+    X86_VENDOR_VORTEX,
+    X86_VENDOR_AO486,
+    X86_VENDOR_AO486_OLD,
+    X86_VENDOR_ZHAOXIN,
+    X86_VENDOR_HYGON,
+    X86_VENDOR_ELBRUS,
+    
+    X86_VENDOR_QEMU,
+    X86_VENDOR_KVM,
+    X86_VENDOR_KVM_ALT,
+    X86_VENDOR_VMWARE,
+    X86_VENDOR_VIRTUALBOX,
+    X86_VENDOR_XEN,
+    X86_VENDOR_HYPERV,
+    X86_VENDOR_PARALLELS,
+    X86_VENDOR_PARALLELS_ALT,
+    X86_VENDOR_BHYVE,
+    X86_VENDOR_QNX
+};
+
+struct cpu_vendor {
+	const char* vendor_name;
+	const char* vendor_sig[2];
+
+	uint8_t vendor;
+	
+	size_t nr_legacy_models;
+	
+	struct {
+		uint8_t x86_family;
+		const char* model_names[16];
+	} legacy_models[];
+};
+
+#define cpu_register_vendor(sym)                                                                   \
+	static const struct cpu_vendor* const __attribute__((section(".cpu_vendor_data")))             \
+	__attribute__((used)) __cpu_vendor_##sym = &sym;
+
+extern const struct cpu_vendor *const *cpu_vendors;
+
+const struct cpu_vendor* cpu_vendor_by_signature(const char* name);
+const char* cpu_vendor_legacy_model(const struct cpu_vendor* vendor, uint8_t x86_family, uint8_t x86_model);

--- a/kernel/include/arch/x86/cpufeature.h
+++ b/kernel/include/arch/x86/cpufeature.h
@@ -1,0 +1,163 @@
+#pragma once
+
+enum cpuid_leafs {
+	CPUID_1_ECX,
+	CPUID_1_EDX,
+
+	CPUID_6_EAX,
+	
+	CPUID_7_EBX,
+
+	CPUID_80000007_EDX,
+
+	NR_CPUID_LEAFS
+};
+
+/* Bit indexes for x86_capability mask */
+
+/* CPUID leaf 0x00000001 (ecx), word 0 */
+#define X86_FEATURE_PNI (0 * 32 + 0)                 /* Streaming SIMD Extensions 3 (SSE3) */
+#define X86_FEATURE_PCLMULQDQ (0 * 32 + 1)           /* PCLMULQDQ instruction support */
+#define X86_FEATURE_DTES64 (0 * 32 + 2)              /* 64-bit DS save area */
+#define X86_FEATURE_MONITOR (0 * 32 + 3)             /* MONITOR/MWAIT support */
+#define X86_FEATURE_DS_CPL (0 * 32 + 4)              /* CPL Qualified Debug Store */
+#define X86_FEATURE_VMX (0 * 32 + 5)                 /* Virtual Machine Extensions */
+#define X86_FEATURE_SMX (0 * 32 + 6)                 /* Safer Mode Extensions */
+#define X86_FEATURE_EST (0 * 32 + 7)                 /* Enhanced Intel SpeedStep */
+#define X86_FEATURE_TM2 (0 * 32 + 8)                 /* Thermal Monitor 2 */
+#define X86_FEATURE_SSSE3 (0 * 32 + 9)               /* Supplemental SSE3 */
+#define X86_FEATURE_CID (0 * 32 + 10)                /* L1 Context ID */
+#define X86_FEATURE_SDBG (0 * 32 + 11)               /* Silicon Debug */
+#define X86_FEATURE_FMA (0 * 32 + 12)                /* FMA extensions using YMM state */
+#define X86_FEATURE_CX16 (0 * 32 + 13)               /* CMPXCHG16B instruction support */
+#define X86_FEATURE_XTPR (0 * 32 + 14)               /* xTPR Update Control */
+#define X86_FEATURE_PDCM (0 * 32 + 15)               /* Perfmon and Debug Capability */
+#define X86_FEATURE_PCID (0 * 32 + 17)               /* Process-context identifiers */
+#define X86_FEATURE_DCA (0 * 32 + 18)                /* Direct Cache Access */
+#define X86_FEATURE_SSE4_1 (0 * 32 + 19)             /* SSE4.1 */
+#define X86_FEATURE_SSE4_2 (0 * 32 + 20)             /* SSE4.2 */
+#define X86_FEATURE_X2APIC (0 * 32 + 21)             /* X2APIC support */
+#define X86_FEATURE_MOVBE (0 * 32 + 22)              /* MOVBE instruction support */
+#define X86_FEATURE_POPCNT (0 * 32 + 23)             /* POPCNT instruction support */
+#define X86_FEATURE_TSC_DEADLINE_TIMER (0 * 32 + 24) /* APIC timer one-shot operation */
+#define X86_FEATURE_AES (0 * 32 + 25)                /* AES instructions */
+#define X86_FEATURE_XSAVE (0 * 32 + 26)              /* XSAVE (and related instructions) support */
+#define X86_FEATURE_OSXSAVE (0 * 32 + 27) /* XSAVE (and related instructions) are enabled by OS */
+#define X86_FEATURE_AVX (0 * 32 + 28)     /* AVX instructions support */
+#define X86_FEATURE_F16C (0 * 32 + 29)    /* Half-precision floating-point conversion support */
+#define X86_FEATURE_RDRAND (0 * 32 + 30)  /* RDRAND instruction support */
+#define X86_FEATURE_HYPERVISOR                                                                     \
+	(0 * 32 + 31) /* System is running as guest; (para-)virtualized system */
+
+/* CPUID leaf 0x00000001 (edx), word 1 */
+#define X86_FEATURE_FPU (1 * 32 + 0)      /* Floating-Point Unit on-chip (x87) */
+#define X86_FEATURE_VME (1 * 32 + 1)      /* Virtual-8086 Mode Extensions */
+#define X86_FEATURE_DE (1 * 32 + 2)       /* Debugging Extensions */
+#define X86_FEATURE_PSE (1 * 32 + 3)      /* Page Size Extension */
+#define X86_FEATURE_TSC (1 * 32 + 4)      /* Time Stamp Counter */
+#define X86_FEATURE_MSR (1 * 32 + 5)      /* Model-Specific Registers (RDMSR and WRMSR support) */
+#define X86_FEATURE_PAE (1 * 32 + 6)      /* Physical Address Extensions */
+#define X86_FEATURE_MCE (1 * 32 + 7)      /* Machine Check Exception */
+#define X86_FEATURE_CX8 (1 * 32 + 8)      /* CMPXCHG8B instruction */
+#define X86_FEATURE_APIC (1 * 32 + 9)     /* APIC on-chip */
+#define X86_FEATURE_SEP (1 * 32 + 11)     /* and associated MSRs */
+#define X86_FEATURE_MTRR (1 * 32 + 12)    /* Memory Type Range Registers */
+#define X86_FEATURE_PGE (1 * 32 + 13)     /* Page Global Extensions */
+#define X86_FEATURE_MCA (1 * 32 + 14)     /* Machine Check Architecture */
+#define X86_FEATURE_CMOV (1 * 32 + 15)    /* Conditional Move Instruction */
+#define X86_FEATURE_PAT (1 * 32 + 16)     /* Page Attribute Table */
+#define X86_FEATURE_PSE36 (1 * 32 + 17)   /* Page Size Extension (36-bit) */
+#define X86_FEATURE_PSN (1 * 32 + 18)     /* Processor Serial Number */
+#define X86_FEATURE_CLFLUSH (1 * 32 + 19) /* CLFLUSH instruction */
+#define X86_FEATURE_DS (1 * 32 + 21)      /* Debug Store */
+#define X86_FEATURE_ACPI (1 * 32 + 22)    /* Thermal monitor and clock control */
+#define X86_FEATURE_MMX (1 * 32 + 23)     /* MMX instructions */
+#define X86_FEATURE_FXSR (1 * 32 + 24)    /* FXSAVE and FXRSTOR instructions */
+#define X86_FEATURE_SSE (1 * 32 + 25)     /* SSE instructions */
+#define X86_FEATURE_SSE2 (1 * 32 + 26)    /* SSE2 instructions */
+#define X86_FEATURE_SS (1 * 32 + 27)      /* Self Snoop */
+#define X86_FEATURE_HT (1 * 32 + 28)      /* Hyper-threading */
+#define X86_FEATURE_TM (1 * 32 + 29)      /* Thermal Monitor */
+#define X86_FEATURE_IA64 (1 * 32 + 30)    /* now reserved */
+#define X86_FEATURE_PBE (1 * 32 + 31)     /* Pending Break Enable */
+
+/* CPUID leaf 0x00000006 (eax), word 2 */
+#define X86_FEATURE_DTHERM                 		(6 * 32 + 0)	/* Digital temperature sensor */
+#define X86_FEATURE_TURBO_BOOST            		(6 * 32 + 1)	/* Intel Turbo Boost */
+#define X86_FEATURE_ARAT                   		(6 * 32 + 2)	/* Always-Running APIC Timer (not affected by p-state) */
+#define X86_FEATURE_PLN                    		(6 * 32 + 4)	/* Power Limit Notification (PLN) event */
+#define X86_FEATURE_ECMD                   		(6 * 32 + 5)	/* Clock modulation duty cycle extension */
+#define X86_FEATURE_PTS                    		(6 * 32 + 6)	/* Package thermal management */
+#define X86_FEATURE_HWP                    		(6 * 32 + 7)	/* HWP (Hardware P-states) base registers are supported */
+#define X86_FEATURE_HWP_NOTIFY             		(6 * 32 + 8)	/* HWP notification (IA32_HWP_INTERRUPT MSR) */
+#define X86_FEATURE_HWP_ACT_WINDOW         		(6 * 32 + 9)	/* HWP activity window (IA32_HWP_REQUEST[bits 41:32]) supported */
+#define X86_FEATURE_HWP_EPP                		(6 * 32 + 10)	/* HWP Energy Performance Preference */
+#define X86_FEATURE_HWP_PKG_REQ            		(6 * 32 + 11)	/* HWP Package Level Request */
+#define X86_FEATURE_HDC_BASE_REGS          		(6 * 32 + 13)	/* HDC base registers are supported */
+#define X86_FEATURE_TURBO_BOOST_3_0        		(6 * 32 + 14)	/* Intel Turbo Boost Max 3.0 */
+#define X86_FEATURE_HWP_CAPABILITIES       		(6 * 32 + 15)	/* HWP Highest Performance change */
+#define X86_FEATURE_HWP_PECI_OVERRIDE      		(6 * 32 + 16)	/* HWP PECI override */
+#define X86_FEATURE_HWP_FLEXIBLE           		(6 * 32 + 17)	/* Flexible HWP */
+#define X86_FEATURE_HWP_FAST               		(6 * 32 + 18)	/* IA32_HWP_REQUEST MSR fast access mode */
+#define X86_FEATURE_HFI                    		(6 * 32 + 19)	/* HW_FEEDBACK MSRs supported */
+#define X86_FEATURE_HWP_IGNORE_IDLE        		(6 * 32 + 20)	/* Ignoring idle logical CPU HWP req is supported */
+#define X86_FEATURE_THREAD_DIRECTOR        		(6 * 32 + 23)	/* Intel thread director support */
+#define X86_FEATURE_THERM_INTERRUPT_BIT25  		(6 * 32 + 24)	/* IA32_THERM_INTERRUPT MSR bit 25 is supported */
+
+/* CPUID leaf 0x00000007:0 (ebx), word 3 */
+#define X86_FEATURE_FSGSBASE (2 * 32 + 0)   /* FSBASE/GSBASE read/write support */
+#define X86_FEATURE_TSC_ADJUST (2 * 32 + 1) /* IA32_TSC_ADJUST MSR supported */
+#define X86_FEATURE_SGX (2 * 32 + 2)        /* Intel SGX (Software Guard Extensions) */
+#define X86_FEATURE_BMI1 (2 * 32 + 3)       /* Bit manipulation extensions group 1 */
+#define X86_FEATURE_HLE (2 * 32 + 4)        /* Hardware Lock Elision */
+#define X86_FEATURE_AVX2 (2 * 32 + 5)       /* AVX2 instruction set */
+#define X86_FEATURE_FDP_EXCPTN_ONLY                                                                \
+	(2 * 32 + 6)                      /* FPU Data Pointer updated only on x87 exceptions */
+#define X86_FEATURE_SMEP (2 * 32 + 7) /* Supervisor Mode Execution Protection */
+#define X86_FEATURE_BMI2 (2 * 32 + 8) /* Bit manipulation extensions group 2 */
+#define X86_FEATURE_ERMS (2 * 32 + 9) /* Enhanced REP MOVSB/STOSB */
+#define X86_FEATURE_INVPCID                                                                        \
+	(2 * 32 + 10)                     /* INVPCID instruction (Invalidate Processor Context ID) */
+#define X86_FEATURE_RTM (2 * 32 + 11) /* Intel restricted transactional memory */
+#define X86_FEATURE_CQM (2 * 32 + 12) /* Intel RDT-CMT / AMD Platform-QoS cache monitoring */
+#define X86_FEATURE_ZERO_FCS_FDS (2 * 32 + 13) /* Deprecated FPU CS/DS (stored as zero) */
+#define X86_FEATURE_MPX (2 * 32 + 14)          /* Intel memory protection extensions */
+#define X86_FEATURE_RDT_A (2 * 32 + 15)        /* Intel RDT / AMD Platform-QoS Enforcement */
+#define X86_FEATURE_AVX512F (2 * 32 + 16)      /* AVX-512 foundation instructions */
+#define X86_FEATURE_AVX512DQ (2 * 32 + 17)     /* AVX-512 double/quadword instructions */
+#define X86_FEATURE_RDSEED (2 * 32 + 18)       /* RDSEED instruction */
+#define X86_FEATURE_ADX (2 * 32 + 19)          /* ADCX/ADOX instructions */
+#define X86_FEATURE_SMAP (2 * 32 + 20)         /* Supervisor mode access prevention */
+#define X86_FEATURE_AVX512IFMA (2 * 32 + 21)   /* AVX-512 integer fused multiply add */
+#define X86_FEATURE_CLFLUSHOPT (2 * 32 + 23)   /* CLFLUSHOPT instruction */
+#define X86_FEATURE_CLWB (2 * 32 + 24)         /* CLWB instruction */
+#define X86_FEATURE_INTEL_PT (2 * 32 + 25)     /* Intel processor trace */
+#define X86_FEATURE_AVX512PF (2 * 32 + 26)     /* AVX-512 prefetch instructions */
+#define X86_FEATURE_AVX512ER (2 * 32 + 27)     /* AVX-512 exponent/reciprocal instructions */
+#define X86_FEATURE_AVX512CD (2 * 32 + 28)     /* AVX-512 conflict detection instructions */
+#define X86_FEATURE_SHA_NI (2 * 32 + 29)       /* SHA/SHA256 instructions */
+#define X86_FEATURE_AVX512BW (2 * 32 + 30)     /* AVX-512 byte/word instructions */
+#define X86_FEATURE_AVX512VL (2 * 32 + 31)     /* AVX-512 VL (128/256 vector length) extensions */
+
+/* CPUID leaf 0x80000007 (edx), word 4 */
+#define X86_FEATURE_DIGITAL_TEMP (3 * 32 + 0)       /* Digital temperature sensor */
+#define X86_FEATURE_POWERNOW_FREQ_ID (3 * 32 + 1)   /* PowerNOW! frequency scaling */
+#define X86_FEATURE_POWERNOW_VOLT_ID (3 * 32 + 2)   /* PowerNOW! voltage scaling */
+#define X86_FEATURE_THERMAL_TRIP (3 * 32 + 3)       /* THERMTRIP (Thermal Trip) */
+#define X86_FEATURE_HW_THERMAL_CONTROL (3 * 32 + 4) /* Hardware thermal control */
+#define X86_FEATURE_SW_THERMAL_CONTROL (3 * 32 + 5) /* Software thermal control */
+#define X86_FEATURE_100MHZ_STEPS (3 * 32 + 6)       /* 100 MHz multiplier control */
+#define X86_FEATURE_HW_PSTATE (3 * 32 + 7)          /* Hardware P-state control */
+#define X86_FEATURE_INVARIANT_TSC                                                                  \
+	(3 * 32 + 8)                     /* TSC ticks at constant rate across all P and C states */
+#define X86_FEATURE_CPB (3 * 32 + 9) /* Core performance boost */
+#define X86_FEATURE_EFF_FREQ_RO (3 * 32 + 10)       /* Read-only effective frequency interface */
+#define X86_FEATURE_PROC_FEEDBACK (3 * 32 + 11)     /* Processor feedback interface (deprecated) */
+#define X86_FEATURE_ACC_POWER (3 * 32 + 12)         /* Processor power reporting interface */
+#define X86_FEATURE_CONNECTED_STANDBY (3 * 32 + 13) /* CPU Connected Standby support */
+#define X86_FEATURE_RAPL (3 * 32 + 14)              /* Runtime Average Power Limit interface */
+
+/* Custom-defined features, word 4 */
+#define X86_FEATURE_CONSTANT_TSC (4 * 32 + 0)   /* TSC ticks at a constant rate */
+#define X86_FEATURE_NONSTOP_TSC (4 * 32 + 1)    /* TSC does not stop in C-states */
+#define X86_FEATURE_TSC_KNOWN_FREQ (4 * 32 + 2) /* TSC has known frequency */

--- a/kernel/include/lib/bitops.h
+++ b/kernel/include/lib/bitops.h
@@ -1,0 +1,82 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* Created by: NotYourFox, 2025 */
+
+#pragma once
+
+#include <common.h>
+#include <lib/math.h>
+#include <stdbool.h>
+#include <arch/bitops.h>
+
+#ifdef SAYORI64
+#define BYTES_PER_LONG 8
+#else
+#define BYTES_PER_LONG 4
+#endif
+
+#define BITS_PER_BYTE   8
+#define BITS_PER_LONG   (BYTES_PER_LONG * BITS_PER_BYTE)
+
+#define BIT_MASK(bit)        (1UL << ((bit) % BITS_PER_LONG))
+#define BIT_WORD(bit)        ((bit) / BITS_PER_LONG)
+
+#define bit_fs(n) __builtin_ffs(n)
+
+static inline void set_bit(unsigned long* addr, unsigned long bit) {
+    unsigned long* p = ((unsigned long*)addr + BIT_WORD(bit));
+    *p |= BIT_MASK(bit);
+}
+
+static inline void clear_bit(unsigned long* addr, unsigned long bit) {
+    unsigned long* p = ((unsigned long*)addr + BIT_WORD(bit));
+    *p &= ~BIT_MASK(bit);
+}
+
+static inline bool test_bit(unsigned long* addr, unsigned long bit) {
+    unsigned long* p = ((unsigned long*)addr + BIT_WORD(bit));
+    return !!(*p & BIT_MASK(bit));
+}
+
+#define BITMAP(name, bits) unsigned long name[bits / BITS_PER_LONG]
+
+#define BITMAP_FIND_NEXT(map, MUNGE, size, start) ({                    \
+    unsigned long res = size;                                           \
+    if (start >= size) goto out;                                        \
+                                                                        \
+    unsigned long chunk;                                                \
+    unsigned long byte_pos = start / BITS_PER_LONG;                     \
+    for (                                                               \
+        chunk = MUNGE(map[byte_pos] & ((~0UL) << start));               \
+        !chunk;                                                         \
+        chunk = MUNGE(map[++byte_pos])                                  \
+    ) {                                                                 \
+        /* Exit loop before we unwantedly read chunk past the end       \
+         * If this is the last chunk and we loop, this means the        \
+         * chunk is 0, so we didn't find the bit */                     \
+        if ((byte_pos + 1) * BITS_PER_LONG >= size) goto out;           \
+    }                                                                   \
+                                                                        \
+    /* bit_fs returns bit pos + 1. We are sure that we have found       \
+     * a non-zero chunk, so no need to check bit_fs. */                 \
+    res = MIN(byte_pos * BITS_PER_LONG + bit_fs(chunk) - 1, size);      \
+                                                                        \
+out:                                                                    \
+    res;                                                                \
+})
+
+/*
+ * Searches for next set bit. If not found, returns size.
+ */
+static inline unsigned long bitmap_find_set(unsigned long* bitmap, unsigned long size, unsigned long start) {
+    return BITMAP_FIND_NEXT(bitmap, /* nop */, size, start);
+}
+
+/*
+ * Searches for next clear bit. If not found, returns size.
+ */
+static inline unsigned long bitmap_find_clear(unsigned long* bitmap, unsigned long size, unsigned long start) {
+    return BITMAP_FIND_NEXT(bitmap, ~, size, start);
+}
+
+#define for_each_set_bit(pos, bitmap, size) \
+    for ((pos) = bitmap_find_set((bitmap), (size), 0); (pos) < (size); (pos) = bitmap_find_set((bitmap), (size), (pos) + 1))

--- a/kernel/include/sys/cpuid.h
+++ b/kernel/include/sys/cpuid.h
@@ -1,56 +1,75 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
 //
 // Created by ndraey on 03.10.23.
+// Modified by: NotYourFox on 06.09.25
 //
+
+/* 
+ * FIXME: CPUID leafs features are arch-dependent a priori. 
+ * Make cpu_info-like structures and capability definitions for each arch separately to improve portability.
+ * cpu_has(), boot_cpu_has() should probably be also used mostly in arch-dependent code.
+ * One can not expect boot_cpu_has(some_x86_feature) on ARMv7 targets.
+ */
 
 #pragma once
 
+#include "arch/x86/cpu_vendors.h"
 #include <common.h>
+#include <lib/bitops.h>
 
-#define cpuid(in, a, b, c, d)    \
-	__asm__ __volatile__("cpuid" \
-	               : "=a" (a),   \
-					 "=b" (b),   \
-					 "=c" (c),   \
-					 "=d" (d)    \
-				   : "a" (in)    \
-    )
+/* x86-relative. */
+#define NR_CAPS 5
 
-#define cpuid_count(in, count, a, b, c, d)    \
-	__asm__ __volatile__("cpuid" \
-	               : "=a" (a),   \
-					 "=b" (b),   \
-					 "=c" (c),   \
-					 "=d" (d)    \
-				   : "0" (in),    \
-				     "2" (count)    \
-    )
+static inline __attribute__((always_inline)) 
+void cpuid(uint32_t leaf, uint32_t* eax, uint32_t* ebx, uint32_t* ecx, uint32_t* edx) {
+	__asm__ volatile("cpuid" : "=a"(*eax), "=b"(*ebx), "=c"(*ecx), "=d"(*edx) : "a"(leaf));
+}
 
-#define INTEL_MAGIC 0x756e6547
-#define AMD_MAGIC   0x68747541
-
+static inline void cpuid_count(uint32_t leaf, uint32_t count, uint32_t* eax, uint32_t* ebx,
+                                 uint32_t* ecx, uint32_t* edx) {
+	__asm__ volatile("cpuid"
+	             : "=a"(*eax), "=b"(*ebx), "=c"(*ecx), "=d"(*edx)
+	             : "0"(leaf), "2"(count));
+}
 
 struct cpu_info {
+    const struct cpu_vendor* vendor;
+    
 	size_t manufacturer_id;
+	
 	size_t model_id;
 	size_t family_id;
-	size_t extended_family_id;
+	
 	size_t type_id;
 	size_t brand_id;
+	
 	size_t stepping_id;
 
-	const char* brand_string;
-	const char* model_string;
-	const char* type_string;
+	char* brand_string;
+	char* model_string;
+	char* type_string;
 
 	size_t l1_i_size;
 	size_t l1_d_size;
 	size_t l2_size;
 	size_t l3_size;
 
-	uint32_t feature_flags_ecx;
-	uint32_t feature_flags_edx;
+	int cpuid_max_leaf;
+	uint32_t extended_cpuid_max_leaf;
+	
+	union {
+		uint32_t cpu_capability[NR_CAPS];
+		unsigned long cpu_capability_alignment;
+	};
 };
 
-size_t cpu_get_id();
-struct cpu_info cpu_get_basic_info();
-bool is_long_mode_supported();
+extern struct cpu_info boot_cpu_info;
+
+#define cpu_has(info, bit)          test_bit((unsigned long *)((info)->cpu_capability), bit)
+#define cpu_set_cap(info, bit)      set_bit((unsigned long *)((info)->cpu_capability), bit)
+#define cpu_clear_cap(info, bit)    clear_bit((unsigned long *)((info)->cpu_capability), bit)
+
+#define boot_cpu_has(bit)           cpu_has(&boot_cpu_info, bit)
+
+void cpu_get_info(struct cpu_info* out);

--- a/kernel/include/sys/cpuid.h
+++ b/kernel/include/sys/cpuid.h
@@ -21,7 +21,7 @@
 /* x86-relative. */
 #define NR_CAPS 5
 
-static inline __attribute__((always_inline)) 
+SAYORI_INLINE
 void cpuid(uint32_t leaf, uint32_t* eax, uint32_t* ebx, uint32_t* ecx, uint32_t* edx) {
 	__asm__ volatile("cpuid" : "=a"(*eax), "=b"(*ebx), "=c"(*ecx), "=d"(*edx) : "a"(leaf));
 }

--- a/kernel/include/sys/cputemp.h
+++ b/kernel/include/sys/cputemp.h
@@ -6,8 +6,6 @@
 
 #include "common.h"
 
-bool is_temperature_module_present();
-
 void cputemp_calibrate();
 
 /**

--- a/kernel/src/arch/x86/bitops.c
+++ b/kernel/src/arch/x86/bitops.c
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* Created by: NotYourFox, 2025 */
+
+#include <lib/bitops.h>
+#include <arch/bitops.h>
+#include <arch/x86/asm.h>
+
+__attribute__((const)) int bit_ls(unsigned long x) {
+	int res;
+
+	if (__builtin_constant_p(x)) return x ? BITS_PER_LONG - __builtin_clz(x) : 0;
+
+	asm(__asm_op("bsr", BYTES_PER_LONG) " %1,%0\n\t"
+	    "jnz 1f\n\t"
+	    "movl $-1,%0\n"
+	    "1:"
+	    : "=r"(res)
+	    : "rm"(x));
+
+	return res + 1;
+}

--- a/kernel/src/arch/x86/cpuinfo.c
+++ b/kernel/src/arch/x86/cpuinfo.c
@@ -1,0 +1,127 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* Created by: NotYourFox, 2025 */
+
+#include "arch/x86/cpu_vendors.h"
+#include <mem/vmm.h>
+#include <stdint.h>
+#include <sys/cpuid.h>
+#include <lib/string.h>
+#include <arch/x86/cpufeature.h>
+
+struct cpu_info boot_cpu_info;
+
+unsigned int x86_family(unsigned int vfms) {
+	unsigned int res;
+
+	res = (vfms >> 8) & 0xF;
+
+	if (res == 0xf) res += (vfms >> 20) & 0xFF;
+
+	return res;
+}
+
+unsigned int x86_model(unsigned int vfms) {
+	unsigned int family, model;
+
+	family = x86_family(vfms);
+
+	model = (vfms >> 4) & 0xF;
+
+	if (family >= 0x6) model += ((vfms >> 16) & 0xF) << 4;
+
+	return model;
+}
+
+unsigned int x86_stepping(unsigned int vfms) {
+	return vfms & 0xF;
+}
+
+static inline bool cpuid_present( ) {
+	uint32_t eax, ebx;
+
+	__asm__ volatile("pushf\n\t"
+	             "movl\t(%%esp), %0\n\t"
+	             "movl\t%0, %1\n\t"
+	             "xorl\t$0x00200000, %0\n\t"
+	             "pushl\t%0\n\t"
+	             "popf\n\t"
+	             "pushf\n\t"
+	             "popl\t%0\n\t"
+	             "popf\n\t"
+
+	             : "=&r"(eax), "=&r"(ebx));
+
+	// rax should have the bit flipped if CPUID is supported
+	return (eax & 0x200000) != (ebx & 0x200000);
+}
+
+void cpu_get_info(struct cpu_info* c) {
+    memset(c, 0x00, sizeof(struct cpu_info));
+    
+    uint32_t eax, ebx, ecx, edx;
+    
+    if (!cpuid_present())  {
+        c->cpuid_max_leaf = -1;
+        return;
+    }
+    
+    c->brand_string = kcalloc(sizeof(char), 13);
+    cpuid(0x00000000, (unsigned int *)&c->cpuid_max_leaf, (unsigned int *)&c->brand_string[0],
+	      (unsigned int *)&c->brand_string[8], (unsigned int *)&c->brand_string[4]);
+    
+    /* Supports CPUID, so at least 4h (Intel 486). */
+	c->family_id = 4;
+
+	c->vendor = cpu_vendor_by_signature(c->brand_string);
+	c->manufacturer_id = c->vendor->vendor;
+	
+	if (c->cpuid_max_leaf >= 0x00000001) {
+		cpuid(0x00000001, &eax, &ebx, &ecx, &edx);
+		c->family_id = x86_family(eax);
+		c->model_id = x86_model(eax);
+		c->stepping_id = x86_stepping(eax);
+
+		c->cpu_capability[CPUID_1_EDX] = edx;
+		c->cpu_capability[CPUID_1_ECX] = ecx;
+	}
+	
+	if (c->cpuid_max_leaf >= 0x00000006) {
+	    cpuid(0x00000006, &eax, &ebx, &ecx, &edx);
+		c->cpu_capability[CPUID_6_EAX] = eax;
+	}
+	
+	if (c->cpuid_max_leaf >= 0x00000007) {
+		cpuid_count(0x00000007, 0, &eax, &ebx, &ecx, &edx);
+		c->cpu_capability[CPUID_7_EBX] = ebx;
+	}
+	
+	c->model_string = kcalloc(sizeof(char), 49);
+	cpuid(0x80000000, &c->extended_cpuid_max_leaf, &ebx, &ecx, &edx);
+	if (c->extended_cpuid_max_leaf >= 0x80000004) {
+		cpuid(0x80000002, (uint32_t *)&c->model_string[0], (uint32_t *)&c->model_string[4],
+		      (uint32_t *)&c->model_string[8], (uint32_t *)&c->model_string[12]);
+		cpuid(0x80000003, (uint32_t *)&c->model_string[16],
+		      (uint32_t *)&c->model_string[20], (uint32_t *)&c->model_string[24],
+		      (uint32_t *)&c->model_string[28]);
+		cpuid(0x80000004, (uint32_t *)&c->model_string[32],
+		      (uint32_t *)&c->model_string[36], (uint32_t *)&c->model_string[40],
+		      (uint32_t *)&c->model_string[44]);
+	} else {
+		strcpy(c->model_string, cpu_vendor_legacy_model(c->vendor, c->family_id, c->model_id));
+	}
+
+	if (c->extended_cpuid_max_leaf >= 0x80000007) {
+		cpuid(0x80000007, &eax, &ebx, &ecx, &edx);
+		c->cpu_capability[CPUID_80000007_EDX] = edx;
+	}
+
+	/* QEMU/KVM have invariant TSC, but do not advertise it. */
+	if (!strcmp(c->brand_string, CPUID_VENDOR_QEMU) || !strcmp(c->brand_string, CPUID_VENDOR_KVM)) {
+		cpu_set_cap(c, X86_FEATURE_INVARIANT_TSC);
+	}
+
+	if (cpu_has(c, X86_FEATURE_INVARIANT_TSC)) {
+		cpu_set_cap(c, X86_FEATURE_CONSTANT_TSC);
+		cpu_set_cap(c, X86_FEATURE_NONSTOP_TSC);
+	}
+}

--- a/kernel/src/arch/x86/cpuvendor.c
+++ b/kernel/src/arch/x86/cpuvendor.c
@@ -1,0 +1,119 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* Created by: NotYourFox, 2025 */
+
+#include <arch/x86/cpu_vendors.h>
+#include <lib/string.h>
+
+extern const struct cpu_vendor *cpu_vendor_start[], *cpu_vendor_end[];
+const struct cpu_vendor *const *cpu_vendors = (const struct cpu_vendor* const *)cpu_vendor_start;
+
+#define NR_X86_VENDORS (int)(cpu_vendor_start - cpu_vendor_end)
+
+const struct cpu_vendor cpu_intel = {
+    .vendor_name = "Intel",
+    .vendor_sig = { CPUID_VENDOR_INTEL },
+    
+    .vendor = X86_VENDOR_INTEL,
+    
+    .nr_legacy_models = 4,
+    .legacy_models = {
+		{ .x86_family = 4, .model_names =
+		  {
+			  [0] = "486 DX-25/33",
+			  [1] = "486 DX-50",
+			  [2] = "486 SX",
+			  [3] = "486 DX/2",
+			  [4] = "486 SL",
+			  [5] = "486 SX/2",
+			  [7] = "486 DX/2-WB",
+			  [8] = "486 DX/4",
+			  [9] = "486 DX/4-WB"
+		  }
+		},
+		{ .x86_family = 5, .model_names =
+		  {
+			  [0] = "Pentium 60/66 A-step",
+			  [1] = "Pentium 60/66",
+			  [2] = "Pentium 75 - 200",
+			  [3] = "OverDrive PODP5V83",
+			  [4] = "Pentium MMX",
+			  [7] = "Mobile Pentium 75 - 200",
+			  [8] = "Mobile Pentium MMX",
+			  [9] = "Quark SoC X1000",
+		  }
+		},
+		{ .x86_family = 6, .model_names =
+		  {
+			  [0] = "Pentium Pro A-step",
+			  [1] = "Pentium Pro",
+			  [3] = "Pentium II (Klamath)",
+			  [4] = "Pentium II (Deschutes)",
+			  [5] = "Pentium II (Deschutes)",
+			  [6] = "Mobile Pentium II",
+			  [7] = "Pentium III (Katmai)",
+			  [8] = "Pentium III (Coppermine)",
+			  [10] = "Pentium III (Cascades)",
+			  [11] = "Pentium III (Tualatin)",
+		  }
+		},
+		{ .x86_family = 15, .model_names =
+		  {
+			  [0] = "Pentium 4 (Unknown)",
+			  [1] = "Pentium 4 (Willamette)",
+			  [2] = "Pentium 4 (Northwood)",
+			  [4] = "Pentium 4 (Foster)",
+			  [5] = "Pentium 4 (Foster)",
+		  }
+		},
+	}
+};
+
+
+const struct cpu_vendor cpu_amd = {
+    .vendor_name = "AMD",
+    .vendor_sig = { CPUID_VENDOR_AMD, CPUID_VENDOR_AMD_OLD },
+    
+    .vendor = X86_VENDOR_AMD,
+
+    .nr_legacy_models = 1,
+    .legacy_models = {
+        { .x86_family = 4, .model_names =
+            {
+                [3] = "486 DX/2",
+                [7] = "486 DX/2-WB",
+                [8] = "486 DX/4",
+                [9] = "486 DX/4-WB",
+                [14] = "Am5x86-WT",
+                [15] = "Am5x86-WB",
+            }
+    	},
+    }
+};
+
+cpu_register_vendor(cpu_intel);
+cpu_register_vendor(cpu_amd);
+
+const struct cpu_vendor* cpu_vendor_by_signature(const char* name) {
+	struct cpu_vendor* cpu_vendor;
+	for (int vendor = 0; vendor < NR_X86_VENDORS; vendor++) {
+		cpu_vendor = cpu_vendors[vendor];
+		if (!strcmp(cpu_vendor->vendor_sig[0], name) ||
+		    (cpu_vendor->vendor_sig[1] && !strcmp(cpu_vendor->vendor_sig[1], name))) {
+			return cpu_vendors[vendor];
+		}
+	}
+
+	return NULL;
+}
+
+const char* cpu_vendor_legacy_model(const struct cpu_vendor* vendor, uint8_t x86_family,
+                                        uint8_t x86_model) {
+                                            
+	for (size_t i = 0; i < vendor->nr_legacy_models; i++) {
+		if (vendor->legacy_models[i].x86_family == x86_family) {
+			return vendor->legacy_models[i].model_names[x86_model];
+		}
+	}
+
+	return NULL;
+}

--- a/kernel/src/arch/x86/link.ld
+++ b/kernel/src/arch/x86/link.ld
@@ -22,6 +22,12 @@ SECTIONS
     {
         DATA_start = .;
 
+        cpu_vendor_start = .;
+        *(.cpu_vendor_data*)
+        cpu_vendor_end = .;
+        
+        . = ALIGN(8);
+
         *(.data*)
 
         DATA_end = .;

--- a/kernel/src/kernel.c
+++ b/kernel/src/kernel.c
@@ -17,6 +17,7 @@
 #include "mem/pmm.h"
 #include "mem/vmm.h"
 #include "drv/audio/ac97.h"
+#include "sys/cpuid.h"
 #include "sys/mtrr.h"
 #include "net/ipv4.h"
 
@@ -183,6 +184,9 @@ void __attribute__((noreturn)) kmain(const multiboot_header_t *mboot, uint32_t i
 
     vmm_init();
     qemu_ok("VMM OK!");
+
+    cpu_get_info(&boot_cpu_info);
+    qemu_log("Boot CPU: %s (%s)", boot_cpu_info.model_string, boot_cpu_info.brand_string);
     
     init_syscalls();
     
@@ -300,6 +304,8 @@ void __attribute__((noreturn)) kmain(const multiboot_header_t *mboot, uint32_t i
 
     tty_printf("\nВлюбиться можно в красоту, но полюбить - лишь только душу.\n(c) Уильям Шекспир\n");
 
+    tty_printf("\nCPU: %s (%s)\n", boot_cpu_info.model_string, boot_cpu_info.brand_string);
+    
     ahci_init();
 
     sayori_time_t time = get_time();

--- a/kernel/src/sys/mtrr.c
+++ b/kernel/src/sys/mtrr.c
@@ -1,3 +1,4 @@
+#include <arch/x86/cpufeature.h>
 #include "common.h"
 #include "sys/cpuid.h"
 #include "io/ports.h"
@@ -11,7 +12,6 @@
 #define WRITEPROTECT 5
 #define WRITEBACK 6
 
-bool mtrr_is_supported = false;
 bool mtrr_wc_available = false;
 bool mtrr_fixed_size_available = false;
 size_t variable_size_mtrrs = 0;
@@ -19,16 +19,10 @@ size_t variable_size_mtrrs = 0;
 #define CALC_MASK(size) (~(size - 1) & 0xffffffff)
 
 void mtrr_init() {
-	uint32_t unused, eax, edx;
+	uint32_t unused, eax;
 
-	cpuid(1, unused, unused, unused, edx);
-
-	qemu_log("%x", edx & (1 << 12));
-
-	if(edx & (1 << 12)) {
-		mtrr_is_supported = true;
-	} else {
-		return;
+	if (!boot_cpu_has(X86_FEATURE_MTRR)) {
+	    return;
 	}
 
 	rdmsr(0xFE, eax, unused);

--- a/kernel/src/sys/syscalls.c
+++ b/kernel/src/sys/syscalls.c
@@ -138,11 +138,7 @@ size_t syscall_munmap(size_t virtual, size_t size) {
 }
 
 size_t syscall_temperature() {
-    if(is_temperature_module_present()) {
-        return get_cpu_temperature();
-    }
-
-    return 0xFFFFFFFF;
+    return get_cpu_temperature();
 }
 
 size_t syscall_mouse(uint32_t* out_x, uint32_t* out_y, uint32_t* flags) {


### PR DESCRIPTION
Changes:
- CPU capability bitmap in `struct cpu_info`
- `cpu_has()`, `cpu_set_cap()`, `cpu_clear_cap()` macros can be now used to test and manipulate CPU capabilities
- `cpu_get_info(struct cpu_info* out)` routine to get all the (supported and defined in `arch/cpufeature.h`) CPU capabilities
- CPU vendor information in `struct cpu_vendor` - contains system-defined CPU vendor/manufacturer IDs and model strings for legacy CPUs, which don't support CPUID leafs 0x80000002-0x80000004.